### PR TITLE
Potential fix for code scanning alert no. 37: Missing rate limiting

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -44,6 +44,13 @@ const authLimiter = rateLimit({
     legacyHeaders: false,
 });
 
+const searchLimiter = rateLimit({
+    windowMs: 5 * 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false
+});
+
 const apiLimiter = rateLimit({
     windowMs: 5 * 60 * 1000,
     handler: (req, res) => {
@@ -289,7 +296,7 @@ app.get('/vehicles', async (req, res) => {
     }
 });
 
-app.get('/search', async (req, res) => {
+app.get('/search', searchLimiter, async (req, res) => {
     // 1. Unique variable for the incoming query string
     const vinQuery = req.query.vin?.trim();
     


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/37](https://github.com/hksiddi4/gm-cars/security/code-scanning/37)

Add a dedicated rate-limiting middleware and attach it directly to the `/search` route so expensive search requests are throttled regardless of any broader middleware ordering.

Best fix in this file:
- In `frontend/server.js`, define a new limiter (for example `searchLimiter`) using `rateLimit(...)` near existing limiter definitions.
- Apply it inline to the `/search` route by changing:
  - `app.get('/search', async (req, res) => { ... })`
  - to `app.get('/search', searchLimiter, async (req, res) => { ... })`
- Keep behavior unchanged otherwise; only rejected over-limit requests should differ (429), which is expected security behavior.

No additional imports are needed because `express-rate-limit` is already imported on line 11.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
