### PR TITLE
Potential fix for code scanning alert no. 24: Client-side cross-site scripting

### DIFF
--- a/frontend/views/pages/vehicles.ejs
+++ b/frontend/views/pages/vehicles.ejs
@@ -497,23 +497,46 @@
 
                     const descArray = rpoDescriptions[code] || [];
 
-                    let descHtml;
+                    const content = document.createElement('span');
+                    content.className = 'rpo-tag-content';
+                    content.style.display = 'inline-flex';
+                    content.style.alignItems = 'center';
+                    content.style.gap = '6px';
+
+                    const strong = document.createElement('strong');
+                    strong.textContent = code;
+                    content.appendChild(strong);
+                    content.appendChild(document.createTextNode(':\u00A0'));
+
                     if (descArray.length > 0) {
-                        descHtml = `<span class="rpo-desc-stack" style="display: inline-flex; flex-direction: column; vertical-align: middle; text-align: left;">`;
+                        const descStack = document.createElement('span');
+                        descStack.className = 'rpo-desc-stack';
+                        descStack.style.display = 'inline-flex';
+                        descStack.style.flexDirection = 'column';
+                        descStack.style.verticalAlign = 'middle';
+                        descStack.style.textAlign = 'left';
+
                         descArray.forEach((desc, index) => {
+                            const item = document.createElement('span');
+                            item.className = 'rpo-desc-item';
+                            item.style.display = 'block';
+                            item.style.lineHeight = '1.3';
                             const trailingComma = index < descArray.length - 1 ? ',' : '';
-                            descHtml += `<span class="rpo-desc-item" style="display: block; line-height: 1.3;">${desc}${trailingComma}</span>`;
+                            item.textContent = `${desc}${trailingComma}`;
+                            descStack.appendChild(item);
                         });
-                        descHtml += `</span>`;
+
+                        content.appendChild(descStack);
                     } else {
-                        descHtml = `<span style="color: gray; font-style: italic;">No description available</span>`;
+                        const noDesc = document.createElement('span');
+                        noDesc.style.color = 'gray';
+                        noDesc.style.fontStyle = 'italic';
+                        noDesc.textContent = 'No description available';
+                        content.appendChild(noDesc);
                     }
 
-                    tag.innerHTML = `
-                        <span class="rpo-tag-content" style="display: inline-flex; align-items: center; gap: 6px;">
-                            <strong>${code}</strong>:&nbsp; ${descHtml} &nbsp;×
-                        </span>
-                    `;
+                    content.appendChild(document.createTextNode('\u00A0×'));
+                    tag.appendChild(content);
 
                     tag.addEventListener('click', () => {
                         const newRpos = rpos.filter(r => r !== code);


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/24](https://github.com/hksiddi4/gm-cars/security/code-scanning/24)

General fix: avoid writing untrusted data through `innerHTML`; instead build DOM nodes and assign untrusted values via `textContent` (or sanitize with a robust HTML sanitizer if HTML is required).

Best fix here (without changing functionality): replace the template-string `tag.innerHTML` block (lines 512–516) with explicit element creation:
- create wrapper span (`rpo-tag-content`)
- create `<strong>` and set `strong.textContent = code`
- add literal punctuation/spacing as text nodes
- for descriptions, build description nodes with `textContent` per item (including commas), or fallback text node for “No description available”
- append a final multiplication sign as text node

This preserves visual output while eliminating script injection from `code` (and avoids any future unsafe HTML insertion in this block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
