### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/views/pages/search.ejs
+++ b/frontend/views/pages/search.ejs
@@ -240,10 +240,30 @@
         startX = event.clientX;
       }
 
+      function getSafeNavigationUrl(rawUrl) {
+        if (!rawUrl || typeof rawUrl !== 'string') return null;
+
+        try {
+          const parsed = new URL(rawUrl, window.location.origin);
+          const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+          const isSameOrigin = parsed.origin === window.location.origin;
+
+          if (!isHttp || !isSameOrigin) return null;
+
+          return parsed.pathname + parsed.search + parsed.hash;
+        } catch (e) {
+          return null;
+        }
+      }
+
       function handleRowClick(url, event) {
         const distance = Math.abs(event.clientX - startX);
         if (distance > 5) return;
-        window.location.href = url;
+
+        const safeUrl = getSafeNavigationUrl(url);
+        if (!safeUrl) return;
+
+        window.location.href = safeUrl;
       }
 
       function loadImageWithRetry(url, retries = 3, delay = 1000) {

--- a/frontend/views/pages/search.ejs
+++ b/frontend/views/pages/search.ejs
@@ -249,8 +249,12 @@
           const isSameOrigin = parsed.origin === window.location.origin;
 
           if (!isHttp || !isSameOrigin) return null;
+          if (!parsed.pathname.startsWith('/')) return null;
 
-          return parsed.pathname + parsed.search + parsed.hash;
+          const safeUrl = parsed.pathname + parsed.search + parsed.hash;
+          if (/%0d|%0a/i.test(safeUrl)) return null;
+
+          return safeUrl;
         } catch (e) {
           return null;
         }
@@ -263,7 +267,7 @@
         const safeUrl = getSafeNavigationUrl(url);
         if (!safeUrl) return;
 
-        window.location.href = safeUrl;
+        window.location.assign(safeUrl);
       }
 
       function loadImageWithRetry(url, retries = 3, delay = 1000) {
@@ -855,9 +859,12 @@
         });
 
         document.querySelectorAll('#rpoTable tbody tr').forEach(row => {
-          const url = row.getAttribute('data-url');
           row.addEventListener('mousedown', handleMouseDown);
-          row.addEventListener('click', (event) => handleRowClick(url, event));
+          row.addEventListener('click', (event) => {
+            const link = row.querySelector('a[href]');
+            if (!link) return;
+            handleRowClick(link.href, event);
+          });
         });
 
         document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/5](https://github.com/hksiddi4/gm-cars/security/code-scanning/5)

To fix this safely without changing intended behavior, validate and normalize the clicked URL before using it for navigation. The best approach here is:

- Accept only safe destinations (preferably same-origin `http/https`, or relative paths resolved against the current origin).
- Reject dangerous schemes like `javascript:`, `data:`, etc.
- If invalid, do nothing (or log a warning) rather than navigating.

### Concrete changes in `frontend/views/pages/search.ejs`

In the `<script>` block where `handleRowClick` is defined (around lines 243–247), add a helper such as `getSafeNavigationUrl(rawUrl)` that:

1. Parses with `new URL(rawUrl, window.location.origin)` to support relative URLs.
2. Checks protocol is `http:` or `https:`.
3. Optionally enforces same-origin (`parsed.origin === window.location.origin`) to preserve current internal-navigation behavior.
4. Returns a safe normalized URL string (e.g., `pathname + search + hash`) or `null`.

Then update `handleRowClick` to call this helper and only assign `window.location.href` when a safe URL is returned.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
