### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/views/pages/rpos.ejs
+++ b/frontend/views/pages/rpos.ejs
@@ -61,6 +61,7 @@
 
         function renderRPOs(model) {
             container.innerHTML = '';
+            if (!Object.prototype.hasOwnProperty.call(allRpos, model)) return;
             const rpos = allRpos[model];
             const missingRpos = [];
 
@@ -68,7 +69,10 @@
                 const cardWrapper = document.createElement('div');
                 cardWrapper.className = 'rpo-wrapper';
                 const link = document.createElement('a');
-                link.href = model === 'corvette' ? `/vehicles?rpo=${rpo}` : `/vehicles?model=${model}&rpo=${rpo}`;
+                const params = new URLSearchParams();
+                if (model !== 'corvette') params.set('model', model);
+                params.set('rpo', rpo);
+                link.href = `/vehicles?${params.toString()}`;
                 link.style.textDecoration = 'none';
 
                 link.className = 'rpo-card-link';


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/25](https://github.com/hksiddi4/gm-cars/security/code-scanning/25)

To fix this safely without changing functionality:

1. **Validate `model` against an allowlist** derived from `allRpos` keys before using it.
2. **Build URLs using `URLSearchParams`** (or equivalent encoding) so `model` and `rpo` are encoded, preventing meta-character reinterpretation.
3. Keep existing behavior for `corvette` special-case query format.

In `frontend/views/pages/rpos.ejs`, update `renderRPOs(model)` to early-return on invalid model and replace line 71 URL interpolation with encoded query construction.

No new imports are needed since this is browser-native JS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
