### PR TITLE
Potential fix for code scanning alert no. 47: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/views/pages/vehicles.ejs
+++ b/frontend/views/pages/vehicles.ejs
@@ -429,8 +429,28 @@
                     return;
                 }
 
-                // Navigate only to the validated internal pathname.
-                window.location.assign(safePathname + parsedUrl.search);
+                // Rebuild a safe query string from allowlisted params only.
+                const allowedQueryParams = new Set(['order', 'year', 'make', 'model', 'trim', 'status', 'stock', 'vin', 'page']);
+                const sanitizedParams = new URLSearchParams();
+                for (const [key, value] of parsedUrl.searchParams.entries()) {
+                    if (!allowedQueryParams.has(key)) {
+                        continue;
+                    }
+
+                    const trimmedValue = value.trim();
+                    if (trimmedValue.length === 0 || trimmedValue.length > 100) {
+                        continue;
+                    }
+
+                    if (!/^[A-Za-z0-9 _.,:+/-]+$/.test(trimmedValue)) {
+                        continue;
+                    }
+
+                    sanitizedParams.set(key, trimmedValue);
+                }
+
+                const safeSearch = sanitizedParams.toString();
+                window.location.assign(safePathname + (safeSearch ? `?${safeSearch}` : ''));
             } catch (e) {
                 return;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/47](https://github.com/hksiddi4/gm-cars/security/code-scanning/47)

Best fix: keep the validated internal pathname logic, but **stop forwarding raw `parsedUrl.search`**. Instead, rebuild a sanitized query string from an allowlist of expected keys and safe values, then navigate with `safePathname + sanitizedSearch`.

In `frontend/views/pages/vehicles.ejs`, update `handleRowClick` around lines 421–433:
- Keep existing origin/path validations.
- Parse `parsedUrl.searchParams`.
- Allow only known filter/sort params used by this page (for example: `order`, `year`, `make`, `model`, `trim`, `status`, `stock`, `vin`, `page`).
- Validate each value with a conservative character allowlist (alnum, space, `_ . , : + / -`) and length cap.
- Rebuild using `URLSearchParams` and append only sanitized entries.
- Call `window.location.assign(safePathname + (sanitized ? '?' + sanitized : ''))`.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
