### PR TITLE
Potential fix for code scanning alert no. 38: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/views/pages/rpos.ejs
+++ b/frontend/views/pages/rpos.ejs
@@ -61,8 +61,9 @@
 
         function renderRPOs(model) {
             container.innerHTML = '';
-            if (!Object.prototype.hasOwnProperty.call(allRpos, model)) return;
-            const rpos = allRpos[model];
+            const safeModel = Object.prototype.hasOwnProperty.call(allRpos, model) ? model : null;
+            if (!safeModel) return;
+            const rpos = allRpos[safeModel];
             const missingRpos = [];
 
             Object.keys(rpos).forEach(rpo => {
@@ -70,7 +71,7 @@
                 cardWrapper.className = 'rpo-wrapper';
                 const link = document.createElement('a');
                 const params = new URLSearchParams();
-                if (model !== 'corvette') params.set('model', model);
+                if (safeModel !== 'corvette') params.set('model', safeModel);
                 params.set('rpo', rpo);
                 link.href = `/vehicles?${params.toString()}`;
                 link.style.textDecoration = 'none';
@@ -81,7 +82,7 @@
                 card.className = 'rpo-card';
 
                 const img = document.createElement('img');
-                img.src = `../img/rpos/${model}/${rpo}.webp`;
+                img.src = `../img/rpos/${encodeURIComponent(safeModel)}/${encodeURIComponent(rpo)}.webp`;
                 img.alt = rpo;
                 img.loading = 'lazy';
                 img.onerror = function() {
@@ -90,9 +91,9 @@
                         const cadillacModels = ['escalade', 'escaladeiq', 'ct4', 'ct4v', 'ct5', 'ct5v'];
                         const gmcModels = ['hummer', 'hummersuv'];
                         let imagePath = '../img/brand-logos/';
-                        if (cadillacModels.includes(model)) {
+                        if (cadillacModels.includes(safeModel)) {
                             imagePath += 'cadillac.webp';
-                        } else if (gmcModels.includes(model)) {
+                        } else if (gmcModels.includes(safeModel)) {
                             imagePath += 'gmc.webp';
                         } else {
                             imagePath += 'chevrolet.webp';


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/38](https://github.com/hksiddi4/gm-cars/security/code-scanning/38)

Best fix: validate `model` against a strict allowlist derived from trusted `allRpos` keys, and construct image paths with URL-encoded path segments before assigning to `img.src`. This preserves existing behavior while preventing unsafe characters or unexpected values from reaching the sink.

In `frontend/views/pages/rpos.ejs`:
- In `renderRPOs(model)`, normalize to a `safeModel` only if it is one of `Object.keys(allRpos)`.
- Use `safeModel` consistently for:
  - key lookup (`allRpos[safeModel]`)
  - query param (`params.set('model', safeModel)`)
  - model checks (`safeModel !== 'corvette'`, brand logo fallback checks)
  - image path construction (`encodeURIComponent(safeModel)` and `encodeURIComponent(rpo)`).
- Keep current UI/functionality unchanged otherwise.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
