### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/views/pages/wheels.ejs
+++ b/frontend/views/pages/wheels.ejs
@@ -156,32 +156,44 @@
                         if (rpo === '5JW') imgRpo = 'WR1';
                         const outsourcedUrl = `https://www.${manufacturer}.com/bypass/master_tools/ddp/gmna/assets/US/${manufacturer}/${year}/${category}/${modelLower}/small_byo3/${imgRpo}.jpg`;
                         const finalImageUrl = getWheelImageUrl(imgRpo, outsourcedUrl, selectedModel);
-                        row.innerHTML = `
-                            <td>
-                                <img 
-                                    class="wheel-image"
-                                    data-rpo="${imgRpo}"
-                                    src="${finalImageUrl}"
-                                    alt="Wheel Image"
-                                    onerror="
-                                        // Outsourced URL fallback for year (if present)
-                                        if (this.src.includes('bypass/master_tools') && !this.dataset.fallback) {
-                                            this.dataset.fallback = 'true';
-                                            this.src = this.src.replace('/${year}/', '/2024/');
-                                        } 
-                                        // Final fallback to generic placeholder
-                                        else if (!this.dataset.placeholder) {
-                                            this.dataset.placeholder = 'true';
-                                            this.src = '/img/placeholder-wheel.webp'; 
-                                        }
-                                    "
-                                />
-                            </td>
-                            <td style="text-align: left;">
-                                <strong>${rpo}</strong>
-                                <div class="rpo-description" data-code="${rpo}" style="margin-top: 4px;"></div>
-                            </td>
-                        `;
+
+                        const imageCell = document.createElement('td');
+                        const img = document.createElement('img');
+                        img.className = 'wheel-image';
+                        img.dataset.rpo = imgRpo;
+                        img.src = finalImageUrl;
+                        img.alt = 'Wheel Image';
+                        img.onerror = function () {
+                            // Outsourced URL fallback for year (if present)
+                            if (this.src.includes('bypass/master_tools') && !this.dataset.fallback) {
+                                this.dataset.fallback = 'true';
+                                this.src = this.src.replace('/' + year + '/', '/2024/');
+                            }
+                            // Final fallback to generic placeholder
+                            else if (!this.dataset.placeholder) {
+                                this.dataset.placeholder = 'true';
+                                this.src = '/img/placeholder-wheel.webp';
+                            }
+                        };
+                        imageCell.appendChild(img);
+
+                        const detailsCell = document.createElement('td');
+                        detailsCell.style.textAlign = 'left';
+
+                        const rpoStrong = document.createElement('strong');
+                        rpoStrong.textContent = rpo;
+
+                        const descDiv = document.createElement('div');
+                        descDiv.className = 'rpo-description';
+                        descDiv.dataset.code = rpo;
+                        descDiv.style.marginTop = '4px';
+
+                        detailsCell.appendChild(rpoStrong);
+                        detailsCell.appendChild(descDiv);
+
+                        row.appendChild(imageCell);
+                        row.appendChild(detailsCell);
+
                         tableBody.appendChild(row);
                     });
 

--- a/frontend/views/pages/wheels.ejs
+++ b/frontend/views/pages/wheels.ejs
@@ -123,6 +123,25 @@
             return outsourcedUrl;
         };
 
+        const getSafeWheelImageUrl = (candidateUrl) => {
+            if (!candidateUrl || typeof candidateUrl !== 'string') return '/img/placeholder-wheel.webp';
+
+            // Allow known-safe local assets
+            if (candidateUrl.startsWith('/img/')) return candidateUrl;
+
+            try {
+                const parsed = new URL(candidateUrl, window.location.origin);
+                const allowedHosts = new Set(['www.cadillac.com', 'www.chevrolet.com']);
+                if (parsed.protocol === 'https:' && allowedHosts.has(parsed.hostname)) {
+                    return parsed.toString();
+                }
+            } catch (e) {
+                // ignore and fall through to placeholder
+            }
+
+            return '/img/placeholder-wheel.webp';
+        };
+
         document.addEventListener('DOMContentLoaded', function () {
             const modelSelect = document.getElementById('filterModel');
             const table = document.getElementById('wheelTable');
@@ -156,12 +175,13 @@
                         if (rpo === '5JW') imgRpo = 'WR1';
                         const outsourcedUrl = `https://www.${manufacturer}.com/bypass/master_tools/ddp/gmna/assets/US/${manufacturer}/${year}/${category}/${modelLower}/small_byo3/${imgRpo}.jpg`;
                         const finalImageUrl = getWheelImageUrl(imgRpo, outsourcedUrl, selectedModel);
+                        const safeImageUrl = getSafeWheelImageUrl(finalImageUrl);
 
                         const imageCell = document.createElement('td');
                         const img = document.createElement('img');
                         img.className = 'wheel-image';
                         img.dataset.rpo = imgRpo;
-                        img.src = finalImageUrl;
+                        img.src = safeImageUrl;
                         img.alt = 'Wheel Image';
                         img.onerror = function () {
                             // Outsourced URL fallback for year (if present)

--- a/frontend/views/pages/wheels.ejs
+++ b/frontend/views/pages/wheels.ejs
@@ -126,8 +126,14 @@
         const getSafeWheelImageUrl = (candidateUrl) => {
             if (!candidateUrl || typeof candidateUrl !== 'string') return '/img/placeholder-wheel.webp';
 
-            // Allow known-safe local assets
-            if (candidateUrl.startsWith('/img/')) return candidateUrl;
+            // Allow known-safe local assets only (block protocol-relative and control chars)
+            if (
+                candidateUrl.startsWith('/img/') &&
+                !candidateUrl.startsWith('//') &&
+                !/[\u0000-\u001F\u007F]/.test(candidateUrl)
+            ) {
+                return candidateUrl;
+            }
 
             try {
                 const parsed = new URL(candidateUrl, window.location.origin);
@@ -149,7 +155,8 @@
             const url = new URL(window.location.href);
 
             modelSelect.addEventListener('change', function () {
-                const selectedModel = this.value?.toUpperCase();
+                const rawModel = (this.value || '').toUpperCase();
+                const selectedModel = Object.prototype.hasOwnProperty.call(modelRpoMap, rawModel) ? rawModel : '';
                 tableBody.innerHTML = '';
 
                 if (selectedModel) url.searchParams.set('model', selectedModel);


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/7](https://github.com/hksiddi4/gm-cars/security/code-scanning/7)

General fix: avoid `innerHTML` for DOM updates that include dynamic content. Build elements with DOM APIs (`createElement`, `textContent`, `setAttribute`/property assignment). This prevents browser HTML re-interpretation of data and preserves existing behavior.

Best targeted fix in `frontend/views/pages/wheels.ejs`:
- Replace the `row.innerHTML = \`...\`` block (lines around 159–184) with explicit element creation.
- Set dynamic values using safe APIs:
  - `img.dataset.rpo = imgRpo`
  - `img.src = finalImageUrl`
  - `rpoStrong.textContent = rpo`
  - `descDiv.dataset.code = rpo`
- Keep the same `onerror` fallback logic by assigning `img.onerror = function () { ... }` in JS (equivalent behavior, safer than inline HTML attribute).

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
