### PR TITLE
Potential fix for code scanning alert no. 39: Information exposure through a stack trace

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -243,7 +243,8 @@ app.get('/about', async (req, res) => {
             pagePath: '/about'
         });
     } catch (err) {
-        res.status(500).render('pages/errors/500', { error: err });
+        console.error("About Route Error:", err);
+        res.status(500).render('pages/errors/500', { pagePath: '/about', canonicalPath: '/about' });
     }
 });
 
@@ -292,7 +293,8 @@ app.get('/vehicles', async (req, res) => {
             canonicalPath: req.originalUrl
         });
     } catch (error) {
-        res.status(500).render('pages/errors/500', { error });
+        console.error("Vehicles Route Error:", error);
+        res.status(500).render('pages/errors/500', { pagePath: '/vehicles', canonicalPath: req.originalUrl });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/39](https://github.com/hksiddi4/gm-cars/security/code-scanning/39)

To fix this, do not pass raw error objects to user-facing templates. Log detailed errors server-side for diagnostics, and render a generic 500 page model for users.

Best minimal fix without changing functionality:
- In `frontend/server.js`, update the `catch` blocks for `/about` and `/vehicles`.
- Replace `res.status(500).render('pages/errors/500', { error: ... })` with a render call that only includes safe page metadata (`pagePath`, `canonicalPath`) or an empty model.
- Add server-side logging in those catch blocks (e.g., `console.error(...)`) to preserve debugging capability.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
