### PR TITLE
Potential fix for code scanning alert no. 35: Information exposure through a stack trace

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -410,7 +410,8 @@ app.get('/stats', async (req, res) => {
             canonicalPath: req.originalUrl
         });
     } catch (error) {
-        res.status(500).render('pages/errors/500', { error });
+        console.error('Error in /stats:', error);
+        res.status(500).render('pages/errors/500', { message: 'Internal server error' });
     }
 });
 
@@ -427,7 +428,8 @@ app.get('/wheels', async (req, res) => {
             canonicalPath: '/wheels'
         });
     } catch (error) {
-        res.status(500).render('pages/errors/500', { error });
+        console.error('Error in /wheels:', error);
+        res.status(500).render('pages/errors/500', { message: 'Internal server error' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/35](https://github.com/hksiddi4/gm-cars/security/code-scanning/35)

To fix this safely without changing functionality, keep returning HTTP 500 with the same error page, but stop sending the caught `error` object to the template. Instead:

1. Log detailed error information on the server (`console.error(...)`) for debugging/operations.
2. Render the error page with only generic, non-sensitive data (or no error data at all).

In `frontend/server.js`, update the two affected `catch` blocks:
- Around lines 412–414 (`/stats`)
- Around lines 429–431 (`/wheels`)

Replace `res.status(500).render('pages/errors/500', { error });` with a server log plus a generic render payload, e.g. `{ message: 'Internal server error' }`. No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
