### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through a stack trace

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -410,7 +410,8 @@ app.get('/stats', async (req, res) => {
             canonicalPath: req.originalUrl
         });
     } catch (error) {
-        res.status(500).render('pages/errors/500', { error });
+        console.error('Error in /stats:', error);
+        res.status(500).render('pages/errors/500', { error: 'Internal Server Error' });
     }
 });
 
@@ -427,7 +428,8 @@ app.get('/wheels', async (req, res) => {
             canonicalPath: '/wheels'
         });
     } catch (error) {
-        res.status(500).render('pages/errors/500', { error });
+        console.error('Error in /wheels:', error);
+        res.status(500).render('pages/errors/500', { error: 'Internal Server Error' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/12](https://github.com/hksiddi4/gm-cars/security/code-scanning/12)

To fix this class of issue, do not send raw exception objects (or stack traces) to user-facing responses. Instead, log detailed error information on the server side for debugging, and render a generic error page payload for clients.

Best fix here (without changing functionality): in `frontend/server.js`, replace both `render(..., { error })` calls in the shown catch blocks with:
1. Server-side logging of the full error (`console.error(...)`).
2. Rendering the same 500 page with a safe, generic value (or no error object).

Concretely, update:
- `/stats` catch block around lines 412–414.
- `/wheels` catch block around lines 429–431.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
