### PR TITLE
Potential fix for code scanning alert no. 31: Information exposure through an exception

### DIFF
--- a/backend/start.py
+++ b/backend/start.py
@@ -110,7 +110,8 @@ def natural_language_query():
             
     except Exception as e:
         close_connection(conn)
-        return jsonify({'error': 'Execution error', 'generated_sql': generated_sql, 'details': str(e)}), 400
+        app.logger.exception("Execution error while running generated SQL")
+        return jsonify({'error': 'Execution error', 'generated_sql': generated_sql}), 400
     
     close_connection(conn)
 


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/31](https://github.com/hksiddi4/gm-cars/security/code-scanning/31)

To fix this safely, do not include raw exception text in API responses. Return a generic client-facing error and log the exception on the server for troubleshooting.

Best minimal fix in `backend/start.py`:
- In the `except Exception as e:` block around `execute_read_query`, replace the response that includes `'details': str(e)` with a generic error payload.
- Add server-side logging of the exception via Flask’s logger (`app.logger.exception(...)`), which preserves full traceback in server logs without exposing it to users.
- Keep existing status code and other response fields (`generated_sql`) unchanged to avoid changing behavior beyond removing sensitive exposure.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
