### PR TITLE
Potential fix for code scanning alert no. 30: Information exposure through an exception

### DIFF
--- a/backend/start.py
+++ b/backend/start.py
@@ -91,8 +91,8 @@ def natural_language_query():
         response = requests.post(OLLAMA_URL, json=payload, timeout=120)
         response.raise_for_status()
         generated_sql = response.json().get('response', '').strip()
-    except Exception as e:
-        return jsonify({'error': f'Failed to communicate with AI model: {str(e)}'}), 500
+    except Exception:
+        return jsonify({'error': 'Failed to communicate with AI model'}), 500
 
     if generated_sql.startswith("```"):
         generated_sql = generated_sql.replace("```sql", "").replace("```", "").strip()


### PR DESCRIPTION
Potential fix for [https://github.com/hksiddi4/gm-cars/security/code-scanning/30](https://github.com/hksiddi4/gm-cars/security/code-scanning/30)

The correct fix is to stop returning raw exception details to the client and instead return a generic, non-sensitive error message, while logging full exception details server-side for debugging.

Best minimal change (without altering functionality): in `backend/start.py`, inside `natural_language_query()`, replace the line returning `str(e)` in the AI communication `except` block with a fixed generic message. This preserves the same HTTP status (500) and response shape (`{'error': ...}`), but removes sensitive exception content from user output.

No additional methods or dependencies are required. No new imports are needed for this minimal safe fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
